### PR TITLE
Fix avatar path constant

### DIFF
--- a/Assets/Resources/Scripts/Props/DefaultProperty.cs
+++ b/Assets/Resources/Scripts/Props/DefaultProperty.cs
@@ -25,7 +25,7 @@ namespace Assets.Resources.Scripts.Props
         public const string PLAYER_ID = "PlayerID";
 
         public const string PLAYER_ENTITIES = "/playerEntities.json";
-        public const string AVATER = "/avatar.png";
+        public const string AVATAR = "/avatar.png";
         public const string PLAYER_DATA = "/playerData.json";
         public const string PLAYER_CARDS_DATA = "/playerCards.json";
         public const string ITEM_DATA = "/itemData.json";

--- a/Assets/Resources/Scripts/Utils/DataUtil.cs
+++ b/Assets/Resources/Scripts/Utils/DataUtil.cs
@@ -245,7 +245,7 @@ namespace Assets.Resources.Scripts.Utils
 
         public string GetPlayerAvatarPath(string playerID)
         {
-            return savePath + "/" + playerID + DefaultProperty.AVATER;
+            return savePath + "/" + playerID + DefaultProperty.AVATAR;
         }
 
         public string EncryptBase64(string plainText)


### PR DESCRIPTION
## Summary
- correct the typo `AVATER` to `AVATAR`
- update all usages of the renamed constant

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68448ecd6c0483328ef7bf64c5613ccf